### PR TITLE
Add autoload so package.use mode can be lazily loaded

### DIFF
--- a/package.use-mode.el
+++ b/package.use-mode.el
@@ -71,6 +71,7 @@
    `(,(rx (1+ whitespace) (1+ (any alnum "_" "-")) ":")
      0 font-lock-constant-face t)))
 
+;;;###autoload
 (define-derived-mode package.use-mode prog-mode "package.use"
   :syntax-table package.use-mode-syntax-table
   :keymap nil


### PR DESCRIPTION
The package.use-mode function is not autoloaded. Since it is added to
auto-mode-alist, emacs tries to enter package.use-mode, but it can't
find the function. Autoloading the mode definition fixes this.