### PR TITLE
Add missing closing > to author's email.

### DIFF
--- a/package.use-mode.el
+++ b/package.use-mode.el
@@ -1,7 +1,7 @@
 ;;; package.use-mode.el --- Emacs mode for editing Gentoo package.use files -*- lexical-binding: t; -*-
 ;; Copyright (C) 2020 C-xC-c
 
-;; Author: C-xC-c <boku@plum.moe
+;; Author: C-xC-c <boku@plum.moe>
 ;; Created: July 2020
 ;; Package-Version: 1.3.0
 ;; Keywords: languages, gentoo


### PR DESCRIPTION
Hi, thank you for your package!

I have the following installation problems

1. Mail-address is missing closing ">": `forward-sexp: Scan error: "Unbalanced parentheses", 8, 22`
2. `Error: Symbol's value as variable is void package.use--characters`

Maybe point 2 can be ignored. 1.) is fixed by this merge-request.